### PR TITLE
Add legacy mapping & ResourceType

### DIFF
--- a/src/athome.rs
+++ b/src/athome.rs
@@ -10,11 +10,11 @@ struct AtHomeServer {
 }
 
 impl Client {
-    pub async fn at_home(&self, chapter_id: Uuid, force_port443: bool) -> Result<Url> {
+    pub async fn at_home(&self, chapter_id: &Uuid, force_port443: bool) -> Result<Url> {
         let mut endpoint = self
             .base_url
             .join("/at-home/server/")?
-            .join(&format!("{}", chapter_id))?;
+            .join(&format!("{:x}", chapter_id))?;
 
         if force_port443 {
             endpoint
@@ -39,7 +39,7 @@ mod tests {
         let client = Client::new().unwrap();
         let chapter_uuid = uuid::Uuid::parse_str("0e94efb5-6cb5-49fd-b522-51b4460c9821").unwrap();
 
-        client.at_home(chapter_uuid, false).await.unwrap();
+        client.at_home(&chapter_uuid, false).await.unwrap();
     }
 
     #[tokio::test]
@@ -47,7 +47,7 @@ mod tests {
         let client = Client::new().unwrap();
         let chapter_uuid = uuid::Uuid::parse_str("0e94efb5-6cb5-49fd-b522-51b4460c9821").unwrap();
 
-        let url = client.at_home(chapter_uuid, true).await.unwrap();
+        let url = client.at_home(&chapter_uuid, true).await.unwrap();
         assert_eq!(url.port_or_known_default(), Some(443));
     }
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,13 +1,13 @@
 use isolanguage_1::LanguageCode;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 pub type LocalizedString = std::collections::HashMap<LanguageCode, String>;
 
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, Deserialize, PartialEq, Eq)]
 pub struct Relationship {
     pub id: Uuid,
-    pub r#type: String,
+    pub r#type: ResourceType,
 }
 
 /// Common values returned in the "result" field from most responses.
@@ -20,15 +20,15 @@ pub enum ApiResult {
     Error,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct ApiObject<T> {
     pub id: Uuid,
-    pub r#type: String,
+    pub r#type: ResourceType,
     pub attributes: T,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct ApiObjectResult<T> {
     pub result: ApiResult,
@@ -45,15 +45,30 @@ pub struct Results<T> {
 }
 
 /// A response for endpoints which only give a simple result.
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, Deserialize)]
 pub struct SimpleApiResponse {
     result: ApiResult,
 }
 
-#[derive(Debug, serde::Serialize, Default)]
+#[derive(Debug, Serialize, Default)]
 pub struct ListRequest {
     pub limit: Option<i32>,
     pub offset: Option<i32>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ResourceType {
+    #[serde(alias = "scanlation_group")]
+    Group,
+    Manga,
+    Chapter,
+    Tag,
+    MappingId,
+    Author,
+    Artist,
+    User,
+    CoverArt,
 }
 
 #[cfg(test)]

--- a/src/legacy.rs
+++ b/src/legacy.rs
@@ -1,1 +1,62 @@
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
+use crate::{errors::ApiErrors, ApiObject, ApiObjectResult, Client, ResourceType, Result};
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MappingQuery {
+    pub r#type: ResourceType,
+    pub ids: Vec<u32>,
+}
+
+type MappingId = ApiObject<MappingIdAttributes>;
+pub type MappingResponse = Vec<ApiObjectResult<MappingId>>;
+
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct MappingIdAttributes {
+    pub r#type: ResourceType,
+    pub legacy_id: u32,
+    pub new_id: Uuid,
+}
+
+impl Client {
+    pub async fn legacy_mapping(&self, query: &MappingQuery) -> Result<MappingResponse> {
+        let endpoint = self.base_url.join("/legacy/mapping")?;
+        let res = self.http.post(endpoint).json(query).send().await?;
+        let res = Self::deserialize_response::<MappingResponse, ApiErrors>(res).await?;
+
+        Ok(res)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[tokio::test]
+    async fn legacy_mapping() {
+        let client = Client::new().unwrap();
+        let mapping = client
+            .legacy_mapping(&MappingQuery {
+                r#type: ResourceType::Manga,
+                ids: vec![1],
+            })
+            .await
+            .unwrap();
+        assert_eq!(
+            mapping[0].data,
+            MappingId {
+                id: Uuid::parse_str("24b6d026-a7cb-498e-8717-26b2831cf318").unwrap(),
+                r#type: ResourceType::MappingId,
+                attributes: MappingIdAttributes {
+                    r#type: ResourceType::Manga,
+                    legacy_id: 1,
+                    new_id: Uuid::parse_str("c0ee660b-f9f2-45c3-8068-5123ff53f84a").unwrap()
+                }
+            }
+        )
+    }
+}


### PR DESCRIPTION
Changes:
- Added a ResourceType enum. This is just a blanket enum for all endpoints for now.
- Changed `at_home()` to take `&Uuid` instead of `Uuid`
- Made `at_home()` chapter id formatting more explicit
- Implemented `/legacy/mapping` endpoint
- Added `#[derive(PartialEq, Eq)]` on some of the common structs/enums to facilitate easier tests.