### PR TITLE
Use Result for api errors

### DIFF
--- a/src/athome.rs
+++ b/src/athome.rs
@@ -1,4 +1,4 @@
-use crate::{errors::ApiErrors, Client, Result};
+use crate::{Client, Result};
 use reqwest::Url;
 use serde::Deserialize;
 use uuid::Uuid;
@@ -23,7 +23,7 @@ impl Client {
         }
 
         let res = self.http.get(endpoint).send().await?;
-        let res = Self::deserialize_response::<AtHomeServer, ApiErrors>(res).await?;
+        let res = res.json::<AtHomeServer>().await?;
 
         Ok(Url::parse(&res.base_url)?)
     }

--- a/src/common.rs
+++ b/src/common.rs
@@ -10,14 +10,12 @@ pub struct Relationship {
     pub r#type: ResourceType,
 }
 
-/// Common values returned in the "result" field from most responses.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum ApiResult {
-    /// There was no error.
-    Ok,
-    /// There was an error.
-    Error,
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ApiData<T> {
+    pub data: T,
+    #[serde(default)]
+    pub relationships: Vec<Relationship>,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Eq)]
@@ -28,13 +26,8 @@ pub struct ApiObject<A, T = ResourceType> {
     pub attributes: A,
 }
 
-#[derive(Debug, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
-pub struct ApiObjectResult<T> {
-    pub result: ApiResult,
-    pub data: T,
-    pub relationships: Vec<Relationship>,
-}
+#[derive(Debug, Serialize, Deserialize)]
+pub struct NoData;
 
 #[derive(Debug, Deserialize)]
 pub struct Results<T> {
@@ -42,12 +35,6 @@ pub struct Results<T> {
     pub limit: i32,
     pub offset: i32,
     pub total: i32,
-}
-
-/// A response for endpoints which only give a simple result.
-#[derive(Debug, Deserialize)]
-pub struct SimpleApiResponse {
-    result: ApiResult,
 }
 
 #[derive(Debug, Serialize, Default)]
@@ -68,68 +55,4 @@ pub enum ResourceType {
     Tag,
     User,
     CustomList,
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use pretty_assertions::assert_eq;
-    use serde::Deserialize;
-
-    #[derive(Debug, Deserialize)]
-    struct MyData {
-        pub result: ApiResult,
-    }
-
-    #[test]
-    fn deserializes_expect_error_struct() {
-        let data = serde_json::json!({
-            "result": "bad"
-        });
-        let data = serde_json::from_value::<MyData>(data);
-        assert!(data.is_err())
-    }
-
-    #[test]
-    fn deserializes_from_struct_ok() {
-        let data = serde_json::json!({
-            "result": "ok"
-        });
-        let data: MyData = serde_json::from_value(data).unwrap();
-        assert_eq!(ApiResult::Ok, data.result);
-    }
-
-    #[test]
-    fn deserializes_from_struct_error() {
-        let data = serde_json::json!({
-            "result": "error"
-        });
-        let data: MyData = serde_json::from_value(data).unwrap();
-        assert_eq!(ApiResult::Error, data.result);
-    }
-
-    #[test]
-    fn deserializes_expect_error() {
-        let data = serde_json::json!("hello");
-        let data = serde_json::from_value::<ApiResult>(data);
-        assert!(data.is_err())
-    }
-
-    #[test]
-    fn deserializes_from_ok() {
-        let data = serde_json::json!("ok");
-        assert_eq!(
-            ApiResult::Ok,
-            serde_json::from_value::<ApiResult>(data).unwrap()
-        );
-    }
-
-    #[test]
-    fn deserializes_from_error() {
-        let data = serde_json::json!("error");
-        assert_eq!(
-            ApiResult::Error,
-            serde_json::from_value::<ApiResult>(data).unwrap()
-        );
-    }
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -22,10 +22,10 @@ pub enum ApiResult {
 
 #[derive(Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
-pub struct ApiObject<T> {
+pub struct ApiObject<A, T = ResourceType> {
     pub id: Uuid,
-    pub r#type: ResourceType,
-    pub attributes: T,
+    pub r#type: T,
+    pub attributes: A,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Eq)]
@@ -59,16 +59,15 @@ pub struct PaginationQuery {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum ResourceType {
-    #[serde(alias = "scanlation_group")]
-    Group,
     Manga,
     Chapter,
-    Tag,
-    MappingId,
+    CoverArt,
     Author,
     Artist,
+    ScanlationGroup,
+    Tag,
     User,
-    CoverArt,
+    CustomList,
 }
 
 #[cfg(test)]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,7 +1,6 @@
+use serde::Deserialize;
 use thiserror::Error;
 use uuid::Uuid;
-
-use crate::common::ApiResult;
 
 /// A enum with all the possible errors.
 #[derive(Debug, Error)]
@@ -22,15 +21,15 @@ pub enum Errors {
     PingError,
 }
 
-#[derive(Debug, Error, PartialEq, Eq, serde::Deserialize)]
+#[derive(Debug, Error, PartialEq, Eq, Deserialize)]
 #[error("bad request")]
 pub struct ApiErrors {
-    pub result: ApiResult,
     /// A list of errors.
-    pub errors: Option<Vec<ApiError>>,
+    #[serde(default)]
+    pub errors: Vec<ApiError>,
 }
 
-#[derive(Debug, Error, PartialEq, Eq, serde::Deserialize)]
+#[derive(Debug, Error, PartialEq, Eq, Deserialize)]
 #[error("api error")]
 pub struct ApiError {
     /// The error id.

--- a/src/legacy.rs
+++ b/src/legacy.rs
@@ -1,22 +1,37 @@
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::{errors::ApiErrors, ApiObject, ApiObjectResult, Client, ResourceType, Result};
+use crate::{errors::ApiErrors, ApiObject, ApiObjectResult, Client, Result};
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum MappingType {
+    Group,
+    Manga,
+    Chapter,
+    Tag,
+}
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MappingQuery {
-    pub r#type: ResourceType,
+    pub r#type: MappingType,
     pub ids: Vec<u32>,
 }
 
-type MappingId = ApiObject<MappingIdAttributes>;
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum MappingIdType {
+    MappingId,
+}
+
+type MappingId = ApiObject<MappingIdAttributes, MappingIdType>;
 pub type MappingResponse = Vec<ApiObjectResult<MappingId>>;
 
 #[derive(Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct MappingIdAttributes {
-    pub r#type: ResourceType,
+    pub r#type: MappingType,
     pub legacy_id: u32,
     pub new_id: Uuid,
 }
@@ -41,7 +56,7 @@ mod tests {
         let client = Client::new().unwrap();
         let mapping = client
             .legacy_mapping(&MappingQuery {
-                r#type: ResourceType::Manga,
+                r#type: MappingType::Manga,
                 ids: vec![1],
             })
             .await
@@ -50,9 +65,9 @@ mod tests {
             mapping[0].data,
             MappingId {
                 id: Uuid::parse_str("24b6d026-a7cb-498e-8717-26b2831cf318").unwrap(),
-                r#type: ResourceType::MappingId,
+                r#type: MappingIdType::MappingId,
                 attributes: MappingIdAttributes {
-                    r#type: ResourceType::Manga,
+                    r#type: MappingType::Manga,
                     legacy_id: 1,
                     new_id: Uuid::parse_str("c0ee660b-f9f2-45c3-8068-5123ff53f84a").unwrap()
                 }

--- a/src/user.rs
+++ b/src/user.rs
@@ -1,5 +1,5 @@
+use crate::ApiObject;
 use serde::Deserialize;
-use uuid::Uuid;
 
 #[derive(Debug, Deserialize)]
 pub struct UserAttributes {
@@ -8,8 +8,9 @@ pub struct UserAttributes {
 }
 
 #[derive(Debug, Deserialize)]
-pub struct User {
-    pub id: Uuid,
-    pub r#type: String,
-    pub attributes: UserAttributes,
+#[serde(rename_all = "snake_case")]
+pub enum UserType {
+    User,
 }
+
+pub type User = ApiObject<UserAttributes, UserType>;


### PR DESCRIPTION
## Changes
This is rather a big set of changes:
- Restructured/renamed some of the types for better compositing:
  - `ApiResult` is now a private enum in `lib.rs` used only for deserializing. Use the helper methods, and include plain-old Result in the type definitions.
  - `ApiObjectResult` is now `ApiData`
  - `ApiObject` now has an optional `ResourceType` type parameter, which can be used to further specialize allowed resource types
- I removed the `async deserialize_response(res: Reponse)` helper function, and replaced it with:
  - `async json_api_result(res: Response)`: Deserialize `ApiResult<T>` into `Result<T>`
  - `async json_api_result_vec(res: Response)`: Deserialize `Vec<ApiResult<T>>` into `Result<Vec<Result<T>>>`
  - `async json_api_results(res: Response)`: Deserialize `Results<ApiResult<T>>` into `Result<Results<Result<T>>>`
  - For the endpoints not using `ApiResult`, I just used `res.json()`, which *should* be fine
- Finally, some miscellaneous changes, were I tried to simplify things a bit:
  - Instead of returning `Result<SimpleApiResponse>`, functions now return `Result<()>`
  - `login()` now returns the `AuthTokens` struct directly, instead of the `LoginReponse`
  - I renamed some of the types to more closely match the api documentation
  - `clear_tokens()` was removed, instead replaced by `set_tokens(None)`

## Notes
I should probably also give an example for how the `common.rs` types are supposed to work.

`ApiResult` is wrapped around object containing a `"result": "?"` field. However it's not supposed to be used directly, instead using `Result` in it's place. so, this json:
```json
{ "result": "ok", "field1": "val1", "field2": "val2" }
```
can be matched like so:
```rust
struct Fields {
  field1: String,
  field2: String
}

impl Client {
  async fn get_fields(&self) -> Result<Fields> {
    // let res = ...;
    Self::json_api_result(res).await
  }
}
```

`ApiData<T>`, is a wrapper for objects of the form:
```json
{ "data": "<T>", "relationships?": [ { "type": "ResourceType", "id": "Uuid" } ] }
```

While `ApiObject<A, T = ResourceType>` matches objects of the form:
```json
{ "id": "Uuid", "type": "<T>", "attributes": "<A>" }
```
Customizing `<T>` allows restricting the supported object types.

As a special case, you can't deserialize `Result<()>`. Instead, you'll need an empty struct. For that, I added a `NoData` struct in `common.rs`

## Comments
Honestly, I still don't fill entirely confident about some of these changes, in particular:
- Ignoring the http status code. I was thinking a check could be added later without too much difficulty, so I left it out for now.
- `json_api_*` set of functions. They seem to work, but I would have preferred something more general. But this is the best solution I could find, if we were to avoid specifying type parameters as much as possible.